### PR TITLE
Updated Workflow API

### DIFF
--- a/.buildkite/build_docs.sh
+++ b/.buildkite/build_docs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+pwd; hostname; date
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 VERSION"
+    echo "Example: $0 1.10.0"
+    exit 1
+fi
+
+VERSION=$1
+
+module load julia/$VERSION
+
+echo "Building documentation..."
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.status(); Pkg.instantiate(); include("docs/make.jl")'

--- a/.buildkite/jobscript.sh
+++ b/.buildkite/jobscript.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pwd; hostname; date
+
+module load julia
+
+echo "Running Tests..."
+julia --project -e 'using Pkg; Pkg.status(); Pkg.test()'
+
+echo "Building Documentation..."
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.status(); Pkg.instantiate(); include("docs/make.jl")'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,7 @@
+steps:
+
+  - label: ":arrow_down: Load AlgebraicJulia pipeline"
+    command: |
+      curl -s https://raw.githubusercontent.com/AlgebraicJulia/.github/main/buildkite/pipeline.yml | buildkite-agent pipeline upload
+
+  - wait

--- a/.buildkite/run_tests.sh
+++ b/.buildkite/run_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+pwd; hostname; date
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 VERSION"
+    echo "Example: $0 1.10.0"
+    exit 1
+fi
+
+VERSION=$1
+
+module load julia/$VERSION
+
+echo "Running tests..."
+julia --project -e "using Pkg; Pkg.status(); Pkg.test()"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,30 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.SERVICE_TOKEN }}

--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -1,0 +1,50 @@
+name: Julia CI/CD
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  push:
+    branches: ["main"]
+    tags: ["*"]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action"
+        required: true
+        default: "test"
+        type: choice
+        options:
+          - test
+          - release
+      version:
+        description: "Tag and release version:"
+        required: false
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  discussions: read
+  issues: read
+  packages: read
+  pages: read
+  pull-requests: write
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+jobs:
+  CI:
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.action == 'test')
+    uses: AlgebraicJulia/.github/.github/workflows/julia_ci.yml@main
+    secrets: inherit
+  CompatHelper:
+    if: github.event_name == 'schedule'
+    uses: AlgebraicJulia/.github/.github/workflows/julia_compat.yml@main
+    secrets: inherit
+  Release:
+    if: github.event_name == 'workflow_dispatch' && inputs.action == 'release' && inputs.version != ''
+    uses: AlgebraicJulia/.github/.github/workflows/julia_release.yml@main
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/examples/data_workflow.jl
+++ b/examples/data_workflow.jl
@@ -1,12 +1,9 @@
-using DataFrames, Query
-using Plots
 using AlgebraicWorkflows
 using Catlab
-using Catlab.Theories
-using Catlab.Present
-using Catlab.CategoricalAlgebra
-using Catlab.Programs
-using Catlab.Graphics
+
+using DataFrames
+using Query
+using Plots
 
 ids = rand(1:100000, 100)
 ages = rand(1:100, 100)

--- a/examples/math.jl
+++ b/examples/math.jl
@@ -1,10 +1,5 @@
 using AlgebraicWorkflows
 using Catlab
-using Catlab.Theories
-using Catlab.Present
-using Catlab.CategoricalAlgebra
-using Catlab.Programs
-using Catlab.Graphics
 
 @present SimpleMath(FreeSymmetricMonoidalCategory) begin
   Val::Ob

--- a/src/AlgebraicWorkflows.jl
+++ b/src/AlgebraicWorkflows.jl
@@ -2,6 +2,9 @@ module AlgebraicWorkflows
 using Reexport
 
 include("Compiler.jl")
-@reexport using .Compiler
+include("Workflows.jl")
 
-end # module
+@reexport using .Compiler
+@reexport using .Workflows
+
+end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -47,7 +47,13 @@ module Compiler
 	    end
 	    out_port_vals[incident(diag, b, :out_port_box)] .= outputs
 	  end
-	  box_vals[execution_order], out_port_vals
+	  out_vals = map(parts(wd.diagram, :OuterOutPort)) do op
+	    owires = incident(wd.diagram, op, :out_tgt)
+	    owire = length(owires) == 1 || error("Output port $op does not have a single input wire.")
+	    owire = only(owires)
+	    out_port_vals[wd.diagram[owire, :out_src]]
+	  end
+	  box_vals[execution_order], out_vals
 	end
 
   """ execute(wd::WiringDiagram, boxes::Dict{Any, Function}, inputs::Vector; kw...)
@@ -59,11 +65,6 @@ module Compiler
 	function execute(wd::WiringDiagram, boxes::Dict{<:Any, <:Function}, inputs::Vector; kw...)
 	  exec_box(wd, b, inputs) = boxes[wd.diagram[b, :value]](inputs...)
 	  _, out_port_vals = compile(wd, exec_box, inputs; track_boxes=false, kw...)
-	  map(parts(wd.diagram, :OuterOutPort)) do op
-	    owires = incident(wd.diagram, op, :out_tgt)
-	    owire = length(owires) == 1 || error("Output port $op does not have a single input wire.")
-	    owire = only(owires)
-	    out_port_vals[wd.diagram[owire, :out_src]]
-	  end
+    out_port_vals
 	end
 end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1,70 +1,67 @@
 module Compiler
-	using Catlab.WiringDiagrams
-	using Catlab.WiringDiagrams: topological_sort
-	using Catlab.CategoricalAlgebra
 
-	export compile, execute
+using Catlab
 
-  """ compile(wd::WiringDiagram, eval_box::Function, inputs::Vector)
+export compile, execute
 
-  Uses the wiring diagram `wd` as a pattern for generating objects from the
-  function provided as `eval_box`.
+"""     compile(wd::WiringDiagram, eval_box::Function, inputs::Vector)
 
-  Expectations for `eval_box`:
-    - input signature: f(wd::WiringDiagram, b::Int, in_ports::Vector; kw...)
-    - output signature:
-      - `track_boxes = true`: (box_val::Any, out_ports::Vector)
-      - `track_boxes = false`: out_ports::Vector
+Uses the wiring diagram `wd` as a pattern for generating objects from the
+function provided as `eval_box`.
 
-  This functions returns the returned box values in compiled order as well as
-  the return values for each output port
-  """
-	function compile(wd::WiringDiagram, eval_box::Function, inputs::Vector;
-	                topo_sort = topological_sort, track_boxes=true, kw...)
-	  diag = wd.diagram
+Expectations for `eval_box`:
+  - input signature: f(wd::WiringDiagram, b::Int, in_ports::Vector; kw...)
+  - output signature:
+    - `track_boxes = true`: (box_val::Any, out_ports::Vector)
+    - `track_boxes = false`: out_ports::Vector
 
-	  execution_order = topo_sort(wd)
-	  out_port_vals = Vector{Any}(undef, nparts(diag, :OutPort))
+This functions returns the returned box values in compiled order as well as
+the return values for each output port
+"""
+function compile(wd::WiringDiagram, eval_box::Function, inputs::Vector; topo_sort = topological_sort, track_boxes=true, kw...)
+    diag = wd.diagram
+
+    execution_order = topo_sort(wd)
+    out_port_vals = Vector{Any}(undef, nparts(diag, :OutPort))
     box_vals = Vector{Any}(nothing, nboxes(wd))
 
-	  for b in execution_order
+    for b in execution_order
+        box_in = map(enumerate(incident(diag, b, :in_port_box))) do (i, p)
+        in_wires = vcat(incident(diag, p, :in_tgt) .* -1, incident(diag, p, :tgt))
+        length(in_wires) == 1 || error("Port $i in box $b in wiring diagram does not have a single input wire.")
+        in_wire = only(in_wires)
+        if in_wire < 0
+          inputs[diag[in_wire * -1, :in_src]]
+        else
+          out_port_vals[diag[in_wire, :src]]
+        end
+    end
 
-	    box_in = map(enumerate(incident(diag, b, :in_port_box))) do (i, p)
-	      in_wires = vcat(incident(diag, p, :in_tgt) .* -1, incident(diag, p, :tgt))
-	      length(in_wires) == 1 || error("Port $i in box $b in wiring diagram does not have a single input wire.")
-	      in_wire = only(in_wires)
-	      if in_wire < 0
-	        inputs[diag[in_wire * -1, :in_src]]
-	      else
-	        out_port_vals[diag[in_wire, :src]]
-	      end
-	    end
+    if track_boxes
+      box_vals[b], outputs = eval_box(wd, b, box_in; kw...)
+    else
+      outputs = eval_box(wd, b, box_in; kw...)
+    end
+    out_port_vals[incident(diag, b, :out_port_box)] .= outputs
+  end
+  out_vals = map(parts(wd.diagram, :OuterOutPort)) do op
+    owires = incident(wd.diagram, op, :out_tgt)
+    owire = length(owires) == 1 || error("Output port $op does not have a single input wire.")
+    owire = only(owires)
+    out_port_vals[wd.diagram[owire, :out_src]]
+  end
+  box_vals[execution_order], out_vals
+end
 
-	    if track_boxes
-	      box_vals[b], outputs = eval_box(wd, b, box_in; kw...)
-	    else
-	      outputs = eval_box(wd, b, box_in; kw...)
-	    end
-	    out_port_vals[incident(diag, b, :out_port_box)] .= outputs
-	  end
-	  out_vals = map(parts(wd.diagram, :OuterOutPort)) do op
-	    owires = incident(wd.diagram, op, :out_tgt)
-	    owire = length(owires) == 1 || error("Output port $op does not have a single input wire.")
-	    owire = only(owires)
-	    out_port_vals[wd.diagram[owire, :out_src]]
-	  end
-	  box_vals[execution_order], out_vals
-	end
+""" execute(wd::WiringDiagram, boxes::Dict{Any, Function}, inputs::Vector; kw...)
 
-  """ execute(wd::WiringDiagram, boxes::Dict{Any, Function}, inputs::Vector; kw...)
-
-  Uses the wiring diagram `wd` as a pattern for executing the functions provided
-  in `boxes`, given the input values in `inputs`. This function assumes that the
-  function signatures in `boxes` correspond to the input/output ports in `wd`.
-  """
-	function execute(wd::WiringDiagram, boxes::Dict{<:Any, <:Function}, inputs::Vector; kw...)
-	  exec_box(wd, b, inputs) = boxes[wd.diagram[b, :value]](inputs...)
-	  _, out_port_vals = compile(wd, exec_box, inputs; track_boxes=false, kw...)
-    out_port_vals
+Uses the wiring diagram `wd` as a pattern for executing the functions provided
+in `boxes`, given the input values in `inputs`. This function assumes that the
+function signatures in `boxes` correspond to the input/output ports in `wd`.
+"""
+  function execute(wd::WiringDiagram, boxes::Dict{<:Any, <:Function}, inputs::Vector; kw...)
+    exec_box(wd, b, inputs) = boxes[wd.diagram[b, :value]](inputs...)
+    _, out_port_vals = compile(wd, exec_box, inputs; track_boxes=false, kw...)
+  out_port_vals
 	end
 end

--- a/src/Workflows.jl
+++ b/src/Workflows.jl
@@ -1,77 +1,71 @@
 module Workflows
 
-using Catlab.Present: Presentation, add_generator!
-using Catlab.Theories: FreeSymmetricMonoidalCategory, ⊗, Ob, Hom
+using Catlab
 import Catlab.Programs: @program
-using Catlab.WiringDiagrams
-using AlgebraicWorkflows.Compiler
+using ..Compiler
 
-export WorkflowComponents, add_type!, add_types!, add_process!, add_processes!,
-       @program, generate_workflow
+export WorkflowComponents, add_type!, add_types!, add_process!, add_processes!, @program, generate_workflow
 
 WorkflowComponents() = Presentation(FreeSymmetricMonoidalCategory)
 VectorLike{T} = Union{AbstractVector{T}, Tuple}
 Process = Pair{Symbol, <:Union{Pair{T, T}, Tuple{T, T}}} where T <: VectorLike{Symbol}
 
-"""WorkflowComponents(types::Vector{Symbol}, processes::Process)
+"""     WorkflowComponents(types::Vector{Symbol}, processes::Process)
 
-Generates a
-[presentation](https://algebraicjulia.github.io/Catlab.jl/stable/generated/sketches/smc/#Presentations)
-which includes the types (as objects) and processes (as homomorphisms) to be
-used in a later workflow definition.
+Generates a [presentation](https://algebraicjulia.github.io/Catlab.jl/stable/generated/sketches/smc/#Presentations)
+which includes the types (as objects) and processes (as homomorphisms) to be used in a later workflow definition.
 """
-function WorkflowComponents(types::Vector{Symbol},
-                            processes::Process...)
-  wf = WorkflowComponents()
-  add_types!(wf, types)
-  add_processes!(wf, processes)
-  wf
+function WorkflowComponents(types::Vector{Symbol}, processes::Process...)
+    wf = WorkflowComponents()
+    add_types!(wf, types)
+    add_processes!(wf, processes)
+    wf
 end
 
-"""add_type!(wf::Presentation, t::Symbol)
+"""     add_type!(wf::Presentation, t::Symbol)
 
 Adds a data type to the presentation
 """
 function add_type!(wf::Presentation, t::Symbol)
-  ob = Ob(FreeSymmetricMonoidalCategory, t)
-  add_generator!(wf, ob)
-  return ob
+    ob = Ob(FreeSymmetricMonoidalCategory, t)
+    add_generator!(wf, ob)
+    return ob
 end
 
-"""add_types!(wf::Presentation, t::Vector{Symbol})
+"""     add_types!(wf::Presentation, t::Vector{Symbol})
 
 Adds multiple data types to the presentation
 """
 function add_types!(wf::Presentation, ts::Vector{Symbol})
-  map(t -> add_type!(wf, t), ts)
+    map(t -> add_type!(wf, t), ts)
 end
 
-"""add_process!(wf::Presentation, t::Process)
+"""     add_process!(wf::Presentation, t::Process)
 
 Adds a process to the presentation
 """
 function add_process!(wf::Presentation, p::Process)
-  p_dom = foldl(⊗, [wf[s] for s in p[2][1]])
-  p_codom = foldl(⊗, [wf[s] for s in p[2][2]])
-  h = Hom(p[1], p_dom, p_codom)
-  add_generator!(wf, h)
-  return h
+    p_dom = foldl(⊗, [wf[s] for s in p[2][1]])
+    p_codom = foldl(⊗, [wf[s] for s in p[2][2]])
+    h = Hom(p[1], p_dom, p_codom)
+    add_generator!(wf, h)
+    return h
 end
 
-"""add_processes!(wf::Presentation, t::VectorLike{Process})
+"""     add_processes!(wf::Presentation, t::VectorLike{Process})
 
 Adds multiple processes to the presentation
 """
 function add_processes!(wf::Presentation, ts::VectorLike{<:Process})
-  map(t -> add_process!(wf, t), ts)
+    map(t -> add_process!(wf, t), ts)
 end
 
 # Helper function for `generate_workflow`
 function box2func(wd::WiringDiagram, b::Int, in_ports::Vector; f_map=f_map)
-  cur_box = box(wd, b)
-  out_vars = [gensym() for o in output_ports(cur_box)]
-  expr = :(($(out_vars...),) = $(f_map[cur_box.value])($(in_ports...)))
-  expr, out_vars
+    cur_box = box(wd, b)
+    out_vars = [gensym() for o in output_ports(cur_box)]
+    expr = :(($(out_vars...),) = $(f_map[cur_box.value])($(in_ports...)))
+    expr, out_vars
 end
 
 """ generate_workflow(wd::WiringDiagram, function_map::Dict{Symbol, <:Function}, type_map::Dict{Symbol, <:Type})
@@ -82,20 +76,18 @@ that `type_map` has an entry for each wire type. This also requires that the
 functions corresponding to the box lables also have consistent signatures with
 the associated boxes in `wd`.
 """
-function generate_workflow(wd::WiringDiagram,
-                           function_map::Dict{Symbol, <:Function},
-                           type_map::Dict{Symbol, <:Type})
-  f_map = deepcopy(function_map)
-  input_types = [type_map[p] for p in input_ports(wd)]
-  inputs = [gensym() for p in input_ports(wd)]
-  body, out_vals = compile(wd, box2func, inputs; f_map = f_map)
-
-  expr = :(function $(gensym())($([Expr(:(::), inputs[i], input_types[i]) for
-                                    i in 1:length(inputs)]...))
-             $(body...)
-             ($(out_vals...),)
-    end)
-  eval(expr)
+function generate_workflow(wd::WiringDiagram, function_map::Dict{Symbol, <:Function}, type_map::Dict{Symbol, <:Type})
+    f_map = deepcopy(function_map)
+    input_types = [type_map[p] for p in input_ports(wd)]
+    inputs = [gensym() for p in input_ports(wd)]
+    body, out_vals = Compiler.compile(wd, box2func, inputs; f_map = f_map)
+  
+    expr = :(function $(gensym())($([Expr(:(::), inputs[i], input_types[i]) for
+                                      i in 1:length(inputs)]...))
+               $(body...)
+               ($(out_vals...),)
+      end)
+    eval(expr)
 end
 
 end

--- a/src/Workflows.jl
+++ b/src/Workflows.jl
@@ -1,0 +1,101 @@
+module Workflows
+
+using Catlab.Present: Presentation, add_generator!
+using Catlab.Theories: FreeSymmetricMonoidalCategory, ⊗, Ob, Hom
+import Catlab.Programs: @program
+using Catlab.WiringDiagrams
+using AlgebraicWorkflows.Compiler
+
+export WorkflowComponents, add_type!, add_types!, add_process!, add_processes!,
+       @program, generate_workflow
+
+WorkflowComponents() = Presentation(FreeSymmetricMonoidalCategory)
+VectorLike{T} = Union{AbstractVector{T}, Tuple}
+Process = Pair{Symbol, <:Union{Pair{T, T}, Tuple{T, T}}} where T <: VectorLike{Symbol}
+
+"""WorkflowComponents(types::Vector{Symbol}, processes::Process)
+
+Generates a
+[presentation](https://algebraicjulia.github.io/Catlab.jl/stable/generated/sketches/smc/#Presentations)
+which includes the types (as objects) and processes (as homomorphisms) to be
+used in a later workflow definition.
+"""
+function WorkflowComponents(types::Vector{Symbol},
+                            processes::Process...)
+  wf = WorkflowComponents()
+  add_types!(wf, types)
+  add_processes!(wf, processes)
+  wf
+end
+
+"""add_type!(wf::Presentation, t::Symbol)
+
+Adds a data type to the presentation
+"""
+function add_type!(wf::Presentation, t::Symbol)
+  ob = Ob(FreeSymmetricMonoidalCategory, t)
+  add_generator!(wf, ob)
+  return ob
+end
+
+"""add_types!(wf::Presentation, t::Vector{Symbol})
+
+Adds multiple data types to the presentation
+"""
+function add_types!(wf::Presentation, ts::Vector{Symbol})
+  map(t -> add_type!(wf, t), ts)
+end
+
+"""add_process!(wf::Presentation, t::Process)
+
+Adds a process to the presentation
+"""
+function add_process!(wf::Presentation, p::Process)
+  p_dom = foldl(⊗, [wf[s] for s in p[2][1]])
+  p_codom = foldl(⊗, [wf[s] for s in p[2][2]])
+  h = Hom(p[1], p_dom, p_codom)
+  add_generator!(wf, h)
+  return h
+end
+
+"""add_processes!(wf::Presentation, t::VectorLike{Process})
+
+Adds multiple processes to the presentation
+"""
+function add_processes!(wf::Presentation, ts::VectorLike{<:Process})
+  map(t -> add_process!(wf, t), ts)
+end
+
+# Helper function for `generate_workflow`
+function box2func(wd::WiringDiagram, b::Int, in_ports::Vector; f_map=f_map)
+  cur_box = box(wd, b)
+  out_vars = [gensym() for o in output_ports(cur_box)]
+  expr = :(($(out_vars...),) = $(f_map[cur_box.value])($(in_ports...)))
+  expr, out_vars
+end
+
+""" generate_workflow(wd::WiringDiagram, function_map::Dict{Symbol, <:Function}, type_map::Dict{Symbol, <:Type})
+
+Generates a function which is an implementation of the wiring diagram `wd`.
+This requires that `function_map` has an entry for each box label in `wd` and
+that `type_map` has an entry for each wire type. This also requires that the
+functions corresponding to the box lables also have consistent signatures with
+the associated boxes in `wd`.
+"""
+function generate_workflow(wd::WiringDiagram,
+                           function_map::Dict{Symbol, <:Function},
+                           type_map::Dict{Symbol, <:Type})
+  f_map = deepcopy(function_map)
+  input_types = [type_map[p] for p in input_ports(wd)]
+  inputs = [gensym() for p in input_ports(wd)]
+  body, out_vals = compile(wd, box2func, inputs; f_map = f_map)
+
+  expr = :(function $(gensym())($([Expr(:(::), inputs[i], input_types[i]) for
+                                    i in 1:length(inputs)]...))
+             $(body...)
+             ($(out_vals...),)
+    end)
+  eval(expr)
+end
+
+end

--- a/test/Compiler.jl
+++ b/test/Compiler.jl
@@ -1,11 +1,7 @@
 using AlgebraicWorkflows
-using Test
 using Catlab
-using Catlab.Theories
-using Catlab.Present
-using Catlab.CategoricalAlgebra
-using Catlab.Programs
-using Catlab.Graphics
+
+using Test
 
 @testset "Simple Math" begin
   @present SimpleMath(FreeSymmetricMonoidalCategory) begin

--- a/test/Workflows.jl
+++ b/test/Workflows.jl
@@ -1,0 +1,92 @@
+using AlgebraicWorkflows
+using Test
+
+@testset "Simple Math" begin
+  SimpleMath = WorkflowComponents([:Real],
+                          :- => ([:Real, :Real], [:Real]),
+                          :+ => ([:Real, :Real], [:Real]),
+                          :* => ([:Real, :Real], [:Real]),
+                          :/ => ([:Real, :Real], [:Real]),
+                          :log => ([:Real], [:Real]),
+                          :√ => ([:Real], [:Real]),
+                          :x² => ([:Real], [:Real]),
+                          :x⁻¹ => ([:Real], [:Real]),
+                          :neg => ([:Real], [:Real]),
+                          :modf => ([:Real], [:Real, :Real])
+                          )
+
+  area = @program SimpleMath (length::Real, width::Real) begin
+    *(length, width)
+  end
+
+  energy = @program SimpleMath (p::Real, m::Real, c::Real) begin
+    csq = x²(c)
+    psq = x²(p)
+    γ = x⁻¹(√(/(-(csq, psq), csq)))
+    *(*(γ, c), m)
+  end
+
+  function_map = Dict(
+    :- => (x,y) -> x - y,
+    :+ => (x,y) -> x + y,
+    :* => (x,y) -> x * y,
+    :/ => (x,y) -> x / y,
+    :log => (x) -> log(x),
+    :√ => (x) -> √(x),
+    :x² => (x) -> x^2,
+    :x⁻¹ => (x) -> 1/x,
+    :modf => (x) -> modf(x),
+    :neg => (x) -> -x
+  )
+  type_map = Dict(:Real => Real)
+
+  area_f = generate_workflow(area, function_map, type_map)
+  @test area_f(1, 2)[1] ≈ 2.0
+
+  energy_f = generate_workflow(energy, function_map, type_map)
+  @test energy_f(sqrt(3/4), 1.0, 1)[1] ≈ 2.0
+
+  # Extend SimpleMath for Complex Math
+  add_type!(SimpleMath, :Imag)
+  add_processes!(SimpleMath,
+                 [:coef => ([:Imag],[:Real]),
+                  :imag => ([:Real],[:Imag]),
+                  :iplus => ([:Real, :Imag, :Real, :Imag],[:Real, :Imag]),
+                  :itimes => ([:Real, :Imag, :Real, :Imag],[:Real, :Imag]),
+                  :mag => ([:Real, :Imag],[:Real])
+                 ])
+
+  function_map[:coef] = x -> x
+  function_map[:imag] = x -> x
+  type_map[:Imag] = Real
+
+  iplus = @program SimpleMath (r1::Real, i1::Imag, r2::Real, i2::Imag) begin
+    +(r1, r2), imag(+(coef(i1), coef(i2)))
+  end
+  function_map[:iplus] = generate_workflow(iplus, function_map, type_map)
+  @test all(function_map[:iplus](1,2,3,4) .≈ [4,6])
+
+  itimes = @program SimpleMath (r1::Real, i1::Imag, r2::Real, i2::Imag) begin
+    r = -(*(r1, r2), *(coef(i1), coef(i2)))
+    i = +(*(r1, coef(i2)), *(r2, coef(i1)))
+    r, imag(i)
+  end
+  function_map[:itimes] = generate_workflow(itimes, function_map, type_map)
+  @test all(function_map[:itimes](1,2,3,4) .≈ [-5,10])
+
+  mag = @program SimpleMath (r::Real, i::Imag) begin
+    r′, i′ = itimes(r, i, r, imag(neg(coef(i))))
+    √(r′)
+  end
+
+  function_map[:mag] = generate_workflow(mag, function_map, type_map)
+
+  test_imag = @program SimpleMath (r::Real, i::Imag) begin
+    rsq, isq = itimes(r, i, r, i)
+    r1, i1 = iplus(rsq, isq, r, i)
+    mag(r1, i1)
+  end
+
+  test_imag_f = generate_workflow(test_imag, function_map, type_map)
+  @test test_imag_f(1,2)[1] ≈ √(40)
+end

--- a/test/Workflows.jl
+++ b/test/Workflows.jl
@@ -1,4 +1,5 @@
 using AlgebraicWorkflows
+
 using Test
 
 @testset "Simple Math" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,7 @@ using Test
 @testset "Compiler" begin
   include("Compiler.jl")
 end
+
+@testset "Workflows" begin
+  include("Workflows.jl")
+end


### PR DESCRIPTION
This PR provides a programmatic interface for working with workflows which keeps the end-user from having to interacting with the more category-theory specific tooling. It also adds a function which generates a Julia function from a workflow definition. A simple example of this interface is shown below:

```julia
# Generate a Presentation with objects A, B and homomorphism add
wf = WorkflowComponents([:A, :B],:add=>([:A, :B], [:A]))

# Define the mapping from the presentation to Julia functions and types
func_map = Dict(:add => (a,b) -> a+b)
type_map = Dict(:A => Int64, :B => Float64)

# Define the workflow
wd = @program wf (a::A, b::B) begin
  add(a,b)
end

# Generate the function to execute
func = generate_workflow(wd, func_map, type_map)
func(1, 2.0) # (3.0,)
```